### PR TITLE
Fix/remove doubled paragraph introduced with PR#22

### DIFF
--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -19,6 +19,7 @@ endif::[]
 [id='sec.major-change']
 == Major Changes
 
+
 [id='sec.1_1']
 == 1.1 Release, April 2018
 
@@ -56,19 +57,7 @@ forward automatically. We recommend always using a values file.
 * To rotate secrets, increment the `kube.secret_generation_counter`
 (immutable generated secrets will not be reset).
 
-* To upgrade {product} 1.0.1 to 1.1, run the following commands:
-+
-[source,bash]
-----
-$ helm repo update
-$ helm upgrade --recreate-pods <uaa-helm-release-name> suse/uaa --values scf-config-values.yaml
-$ SECRET=$(kubectl get pods --namespace uaa -o jsonpath='{.items[*].spec.containers[?(.name=="uaa")].env[?(.name=="INTERNAL_CA_CERT")].valueFrom.secretKeyRef.name}')
-$ CA_CERT="$(kubectl get secret $SECRET --namespace uaa -o jsonpath="{.data['internal-ca-cert']}" | base64 --decode -)"
-$ helm upgrade --recreate-pods <scf-helm-release-name> suse/cf --values scf-config-values.yaml --set "secrets.UAA_CA_CERT=${CA_CERT}"
-$ helm upgrade --recreate-pods <console-helm-release-name> suse/console --values scf-config-values.yaml
-----
-
-** The `kube.external_ip` variable has been changed to `kube.external_ips`,
+* The `kube.external_ip` variable has been changed to `kube.external_ips`,
 allowing for services to be exposed on multiple Kubernetes worker nodes (for
 example, behind a TCP load balancer). Before upgrading, change the setting or
 add a new setting specified as an array. For example:
@@ -86,7 +75,7 @@ those in mixed version environments. To specify multiple addresses, use:
 kube.external_ips=["1.1.1.1", "2.2.2.2"]
 ----
 
-** Upgrading from {product} 1.0.1 to 1.1
+* Upgrading from {product} 1.0.1 to 1.1
 +
 An example `scf-config-values.yaml` for {product} 1.1 would look like this:
 +
@@ -136,6 +125,7 @@ $ CA_CERT="$(kubectl get secret $SECRET --namespace uaa -o jsonpath="{.data['int
 $ helm upgrade --recreate-pods <scf-helm-release-name> suse/cf --values scf-config-values.yaml --set "secrets.UAA_CA_CERT=${CA_CERT}"
 $ helm upgrade --recreate-pods <console-helm-release-name> suse/console --values scf-config-values.yaml
 ----
+
 
 [id='sec.1_1.issue']
 === Known Issues


### PR DESCRIPTION
Removed doubled "How to upgrade" section in adoc/Release-Notes.adoc - this brings back the related structure from before (0f64b129a6b4d909f5e64de7d4eb792bdf57f99b).