### PR TITLE
Update Notes-Azure.adoc

### DIFF
--- a/adoc/Notes-Azure.adoc
+++ b/adoc/Notes-Azure.adoc
@@ -24,6 +24,7 @@ https://azure.microsoft.com/en-us/services/container-service[Microsoft Azure
 Container Service (ACS)]. This document describes how to prepare the ACS
 environment for deployment of {product}. For more detailed product
 information and instructions, see the {product} documentation at {doc-url}.
+Please note: {product} is not currently supported on AKS (Managed Kubernetes).
 
 
 [id='sec.azure.requirement']

--- a/adoc/Notes-Azure.adoc
+++ b/adoc/Notes-Azure.adoc
@@ -21,7 +21,7 @@ endif::[]
 
 {product} {version} supports running on
 https://azure.microsoft.com/en-us/services/container-service[Microsoft Azure
-Container Service (AKS)]. This document describes how to prepare the AKS
+Container Service (ACS)]. This document describes how to prepare the ACS
 environment for deployment of {product}. For more detailed product
 information and instructions, see the {product} documentation at {doc-url}.
 


### PR DESCRIPTION
Updated references from AKS to ACS - SCF will not deploy to AKS with these instructions and the examples given are all using ACS.
AKS doesn't support RBAC at the moment either which seems to cause issues deploying to it. This has caused some customer confusion where they're creating the AKS cluster manually through the AZ portal then hoping to deploy scf on top (which doesn't seem to work). They should be guided to use ACS from the start.