### PR TITLE
Future-proof BBS workaround

### DIFF
--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -56,10 +56,10 @@ Do the following to unblock the upgrade:
 ----
 kubectl exec -it mysql-0 --namespace cf -- env TERM=xterm /bin/bash
 ----
-** Use `msql` to connect to the diego database
+** Use `mysql` to connect to the diego database
 +
 ----
-mysql --password=$MYSQL_ADMIN_PASSWORD diego
+mysql --defaults-file=/var/vcap/jobs/mysql/config/mylogin.cnf diego
 ----
 ** Remove the offending entry
 +


### PR DESCRIPTION
The new mysql command works on 2.10.1 and the latest develop with the CF 1.36 bump.