### PR TITLE
Removed syslog line from 1.3.0

### DIFF
--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -63,7 +63,6 @@ For information about deploying and administering {product}, see the product man
 * `consul` and `postgres` roles removed as they had become redundant
 * {k8s} readiness check no longer looks for `hyperkube` explicitly
 * Updated cluster role names to ensure no namespace conflicts in {k8s}
-* Corrected service name to work with `syslog` drains
 * Includes these {cf} component versions:
 ** UAA: v60.2
 ** cf-deployment: 2.7.0


### PR DESCRIPTION
Fix detailed in entry "Corrected service name to work with `syslog` drains" landed after 1.3.0 GMC. It will be in 1.3.1, so we can re-add there. Potentially we have to include a reference that all drains won't log until rsyslog is manually restarted for now.