### PR TITLE
recreate pods no longer needed for 1.3.1

### DIFF
--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -105,7 +105,7 @@ For information about deploying and administering {product}, see the product man
 [id='sec.1_3_1.issue']
 ==== Known Issues
 
-* Starting with {product} 1.3.1, during helm upgrade from 1.3.0, the `--recreate-pods` is no longer required as the recent change to the active/passive model allowed for previously Unready pods to be upgraded. This will allow for zero app downtime.
+* For {product} 1.3.1, during the helm upgrade from 1.3.0, the `--recreate-pods` is not required as the recent change to the active/passive model allowed for previously Unready pods to be upgraded. This will allow for zero app downtime from the previous version.
 
 * For deployments on {eksa}: the {awsa} Service Broker (https://aws.amazon.com/partners/servicebroker/) should now be used instead of the deprecated `cf-brokers` wrapper.
 

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -105,6 +105,8 @@ For information about deploying and administering {product}, see the product man
 [id='sec.1_3_1.issue']
 ==== Known Issues
 
+* Starting with {product} 1.3.1, during helm upgrade from 1.3.0, the `--recreate-pods` is no longer required as the recent change to the active/passive model allowed for previously Unready pods to be upgraded. This will allow for zero app downtime.
+
 * For deployments on {eksa}: the {awsa} Service Broker (https://aws.amazon.com/partners/servicebroker/) should now be used instead of the deprecated `cf-brokers` wrapper.
 
 * For custom PSPs, `SYS_RESOURCE` no longer needs to be specified under added capabilities in the `scf-config-values.yml`


### PR DESCRIPTION
Confirmed by QA. We received word from upstream of an issue where it's still required but we were unable to reproduce.