### PR TITLE
prepping for 1.4.1

### DIFF
--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -1,4 +1,4 @@
-= Release Notes: SUSE Cloud Application Platform 1.4
+= Release Notes: SUSE Cloud Application Platform 1.4.1
 
 include::entities.adoc[]
 :azuredocurl: https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/cha_cap_depl-azure.html

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -45,19 +45,19 @@ endif::[]
 [id='sec.1_4_1.feature']
 ==== Features and Fixes
 
-* Set the default value of AZ_LABEL_NAME to failure-domain.beta.kubernetes.io/zone
+* Set the default value of `AZ_LABEL_NAME` to `failure-domain.beta.kubernetes.io/zone`
 * Simplified service accounts and pod security policies
 * Switched to log-cache for container metrics
 * Implemented a patch to squash Cloud Controller database migrations
-* Fixed version and SHA1 of cf-mysql-release 36.15.0
-* Fixed TLS issues in log-cache
+* Fixed version and SHA1 of `cf-mysql-release` 36.15.0
+* Fixed TLS issues in `log-cache`
 
 * Includes these {cf} component versions:
 
 ** app-autoscaler: 1.2.1
-** bits-service: 
-** bpm: 
-** capi: 
+** bits-service: 2.26.0
+** bpm: 1.0.0
+** capi: 1.79.0
 ** cats: 7.11
 ** cf-deployment: 7.11
 ** cf-mysql: 36.15.0

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -40,7 +40,7 @@ endif::[]
 ==== What Is New?
 
 * {scf} has been updated to version 2.17.1.
-* Added option to deploy UAA from the SCF Helm chart. In new CAP deployments that do not require a separate UAA deployment, setting `enable.uaa=true` in the Helm values automatically creates a UAA StatefulSet within the SCF deployment. This removes the manual step of copying the UAA_CA_CERT during setup. In this configuration UAA uses the same database as SCF, reducing the memory footprint of the cluster. This option should be left as `false` (default) for upgrades of existing CAP clusters.
+* Added option to deploy UAA from the SCF Helm chart. If you are newly deploying CAP and do not require a separate UAA deployment, you can now generate a UAA StatefulSet within the SCF deployment. To do so, set `enable.uaa=true` in the Helm values. This means there is no need to copy the `UAA_CA_CERT` during setup. In this configuration, UAA uses the same database as SCF, reducing the memory footprint of the cluster. If you are upgrading an existing CAP cluster, this option should be left as `false` (default).
 
 [id='sec.1_4_1.feature']
 ==== Features and Fixes
@@ -97,9 +97,9 @@ endif::[]
 [id='sec.1_4_1.issue']
 ==== Known Issues
 
-* `cf-deployment` 7.11 is the final Cloud Foundry version that supports the `cflinuxfs2` stack. The `cflinuxfs2` and `sle12` stacks are deprecated in favor of `cflinuxfs3` and `sle15` respectively. Start planning to migrate applications to those stacks for futureproofing, as these stacks will be removed in a future release. The Stack Auditor plugin for `cf` can help with this migration (see https://docs.cloudfoundry.org/adminguide/stack-auditor.html). 
+* `cf-deployment` 7.11 is the last Cloud Foundry version that supports the `cflinuxfs2` stack. The `cflinuxfs2` and `sle12` stacks are deprecated in favor of `cflinuxfs3` and `sle15` respectively. Start planning to migrate applications to those stacks for futureproofing, as these stacks will be removed in a future release. The Stack Auditor plugin for `cf` can help with this migration (see https://docs.cloudfoundry.org/adminguide/stack-auditor.html). 
 
-* Do not use the new `enable.uaa=true` SCF chart setting in upgrades of existing CAP 1.4.0 clusters. This will cause a new UAA role to be created which SCF will use instead of the existing UAA deployment. This option is disabled by default in the chart values. 
+* As noted above, do not use the new `enable.uaa=true` SCF chart setting in upgrades of existing CAP 1.4.0 clusters. This will cause a new UAA role to be created which SCF will use instead of the existing UAA deployment. This option is disabled by default in the chart values. 
 
 
 [id='sec.1_4']

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -3,7 +3,7 @@ ifdef::env-github[]
 :suse: SUSE
 :current-year: 2019
 :product: {suse} Cloud Application Platform
-:version: 1.4
+:version: 1.4.1
 :rn-url: https://www.suse.com/releasenotes
 :doc-url: https://www.suse.com/documentation/cloud-application-platform-1
 :deployment-url: https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/part_cap_deployment.html

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -164,6 +164,7 @@ For information about deploying and administering {product}, see the product man
 ** loggregator: 104.4
 ** loggregator-agent: 3.2
 ** nats: 26
+** nfs-volume: 1.5.2
 ** postgres-release: 26
 ** scf-helper: 1.0.2
 ** cf-acceptance-tests: 

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -49,7 +49,7 @@ endif::[]
 * Simplified service accounts and pod security policies
 * Switched to log-cache for container metrics
 * Implemented a patch to squash Cloud Controller database migrations
-* Fixed version and SHA1 of `cf-mysql-release` 36.15.0
+* Fixed version and SHA1 of `cf-mysql-release` tied to version 36.15.0
 * Fixed TLS issues in `log-cache`
 
 * Includes these {cf} component versions:

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -61,27 +61,26 @@ endif::[]
 ** cats: 7.11
 ** cf-deployment: 7.11
 ** cf-mysql: 36.15.0
-** cf-routing: 0.184.0
+** cf-routing: 0.187.0
 ** cf-sle12: 1.75.11
-** cf-smoke-tests: 40.0.44
-** cf-syslog-drain: 8.1
+** cf-smoke-tests: 40.0.51
+** cf-syslog-drain: 10.0
 ** cf-usb: 1.0.1
 ** cflinuxfs2: 1.281.0
 ** cflinuxfs3: 0.108.0
 ** credhub: 2.1.2
-** diego: 2.25.0
+** diego: 2.30.0
 ** eirini: 0.0.4
-** garden-runc: 1.17.2
+** garden-runc: 1.19.1
 ** groot-btrfs: 1.0.4
 ** kubectl: 1.9.6
-** loggregator: 104.4
-** loggregator-agent: 3.2
+** loggregator: 105.2
+** loggregator-agent: 3.9
 ** nats: 26
-** nfs-volume: 1.7.6
+** nfs-volume: 1.5.2
 ** postgres-release: 26
 ** scf-helper: 1.0.2
-** cf-acceptance-tests: 
-** statsd-injector: 1.5.0
+** statsd-injector: 1.9.0
 ** uaa: 68.0
 * Buildpacks:
 ** binary-buildpack: 1.0.32
@@ -165,7 +164,6 @@ For information about deploying and administering {product}, see the product man
 ** loggregator: 104.4
 ** loggregator-agent: 3.2
 ** nats: 26
-** nfs-volume: 1.7.6
 ** postgres-release: 26
 ** scf-helper: 1.0.2
 ** cf-acceptance-tests: 

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -39,8 +39,8 @@ endif::[]
 [id='sec.1_4_1.new']
 ==== What Is New?
 
-* {scf} has been updated to version 2.17.1:
-** Added support for embedded UAA, which allows UAA and SCF to reside in the same chart for environments that don't require a separate UAA chart. 
+* {scf} has been updated to version 2.17.1.
+* Added option to deploy UAA from the SCF Helm chart. In new CAP deployments that do not require a separate UAA deployment, setting `enable.uaa=true` in the Helm values automatically creates a UAA StatefulSet within the SCF deployment. This removes the manual step of copying the UAA_CA_CERT during setup. In this configuration UAA uses the same database as SCF, reducing the memory footprint of the cluster. This option should be left as `false` (default) for upgrades of existing CAP clusters.
 
 [id='sec.1_4_1.feature']
 ==== Features and Fixes
@@ -98,14 +98,9 @@ endif::[]
 [id='sec.1_4_1.issue']
 ==== Known Issues
 
-* With `cf-deployment` 7.11, that marks the final CF version that supports the `cflinuxfs2` stack. Future CAP versions will incorporate more recent `cf-deployment` versions that will only work with `cflinuxfs3` or `sle15` stacks, so you should start planning to moving your apps to those stacks for futureproofing.
+* `cf-deployment` 7.11 is the final Cloud Foundry version that supports the `cflinuxfs2` stack. The `cflinuxfs2` and `sle12` stacks are deprecated in favor of `cflinuxfs3` and `sle15` respectively. Start planning to migrate applications to those stacks for futureproofing, as these stacks will be removed in a future release. The Stack Auditor plugin for `cf` can help with this migration (see https://docs.cloudfoundry.org/adminguide/stack-auditor.html). 
 
-* The embedded UAA option makes it simpler to deploy and upgrade when the UAA is not being shared between multiple projects. Instead of installing a separate UAA chart, and then exporting the CA cert so it can be shared with SCF, all you have to do is add one option to the SCF install:
-+
-[source]
-----
-helm install ... --set enable.uaa=true
-----
+* Do not use the new `enable.uaa=true` SCF chart setting in upgrades of existing CAP 1.4.0 clusters. This will cause a new UAA role to be created which SCF will use instead of the existing UAA deployment. This option is disabled by default in the chart values. 
 
 
 [id='sec.1_4']

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -33,6 +33,81 @@ endif::[]
 [id='sec.major-change']
 == Major Changes
 
+[id='sec.1_4_1']
+=== Release 1.4.1, July 2019
+
+[id='sec.1_4_1.new']
+==== What Is New?
+
+* {scf} has been updated to version 2.17.1:
+** Added support for embedded UAA, which allows UAA and SCF to reside in the same chart for environments that don't require a separate UAA chart. 
+
+[id='sec.1_4_1.feature']
+==== Features and Fixes
+
+* Set the default value of AZ_LABEL_NAME to failure-domain.beta.kubernetes.io/zone
+* Simplified service accounts and pod security policies
+* Switched to log-cache for container metrics
+* Implemented a patch to squash Cloud Controller database migrations
+* Fixed version and SHA1 of cf-mysql-release 36.15.0
+* Fixed TLS issues in log-cache
+
+* Includes these {cf} component versions:
+
+** app-autoscaler: 1.2.1
+** bits-service: 
+** bpm: 
+** capi: 
+** cats: 7.11
+** cf-deployment: 7.11
+** cf-mysql: 36.15.0
+** cf-routing: 0.184.0
+** cf-sle12: 1.75.11
+** cf-smoke-tests: 40.0.44
+** cf-syslog-drain: 8.1
+** cf-usb: 1.0.1
+** cflinuxfs2: 1.281.0
+** cflinuxfs3: 0.108.0
+** credhub: 2.1.2
+** diego: 2.25.0
+** eirini: 0.0.4
+** garden-runc: 1.17.2
+** groot-btrfs: 1.0.4
+** kubectl: 1.9.6
+** loggregator: 104.4
+** loggregator-agent: 3.2
+** nats: 26
+** nfs-volume: 1.7.6
+** postgres-release: 26
+** scf-helper: 1.0.2
+** cf-acceptance-tests: 
+** statsd-injector: 1.5.0
+** uaa: 68.0
+* Buildpacks:
+** binary-buildpack: 1.0.32
+** dotnet-core-buildpack: 2.2.12
+** go-buildpack: 1.8.41
+** java-buildpack: 4.19.1 
+** nginx-buildpack: 1.0.14
+** nodejs-buildpack: 1.6.51
+** php-buildpack: 4.3.77
+** python-buildpack: 1.6.34
+** ruby-buildpack: 1.7.40
+** staticfile-buildpack: 1.4.43
+
+[id='sec.1_4_1.issue']
+==== Known Issues
+
+* With `cf-deployment` 7.11, that marks the final CF version that supports the `cflinuxfs2` stack. Future CAP versions will incorporate more recent `cf-deployment` versions that will only work with `cflinuxfs3` or `sle15` stacks, so you should start planning to moving your apps to those stacks for futureproofing.
+
+* The embedded UAA option makes it simpler to deploy and upgrade when the UAA is not being shared between multiple projects. Instead of installing a separate UAA chart, and then exporting the CA cert so it can be shared with SCF, all you have to do is add one option to the SCF install:
++
+[source]
+----
+helm install ... --set enable.uaa=true
+----
+
+
 [id='sec.1_4']
 === Release 1.4, May 2019
 

--- a/adoc/Release-Notes.adoc
+++ b/adoc/Release-Notes.adoc
@@ -45,12 +45,12 @@ endif::[]
 [id='sec.1_4_1.feature']
 ==== Features and Fixes
 
-* Set the default value of `AZ_LABEL_NAME` to `failure-domain.beta.kubernetes.io/zone`
-* Simplified service accounts and pod security policies
-* Switched to log-cache for container metrics
-* Implemented a patch to squash Cloud Controller database migrations
-* Fixed version and SHA1 of `cf-mysql-release` tied to version 36.15.0
-* Fixed TLS issues in `log-cache`
+* Set the default value of `AZ_LABEL_NAME` to `failure-domain.beta.kubernetes.io/zone`.
+* Simplified service accounts and pod security policies.
+* Switched to log-cache for container metrics.
+* Implemented a patch to squash Cloud Controller database migrations.
+* Fixed version and SHA1 of `cf-mysql-release` tied to version 36.15.0.
+* Fixed TLS issues in `log-cache`.
 
 * Includes these {cf} component versions:
 

--- a/adoc/entities.adoc
+++ b/adoc/entities.adoc
@@ -1,7 +1,7 @@
 :suse: SUSE
 :current-year: 2019
 :product: {suse} Cloud Application Platform
-:version: 1.4
+:version: 1.4.1
 :rn-url: https://www.suse.com/releasenotes
 :doc-url: https://www.suse.com/documentation/cloud-application-platform-1
 :deployment-url: https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/part_cap_deployment.html

--- a/adoc/legal.adoc
+++ b/adoc/legal.adoc
@@ -3,7 +3,7 @@ ifdef::env-github[]
 :suse: SUSE
 :current-year: 2019
 :product: {suse} Cloud Application Platform
-:version: 1.4
+:version: 1.4.1
 :rn-url: https://www.suse.com/releasenotes
 :doc-url: https://www.suse.com/documentation/cloud-application-platform-1
 :deployment-url: https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/part_cap_deployment.html

--- a/adoc/source-code.adoc
+++ b/adoc/source-code.adoc
@@ -3,7 +3,7 @@ ifdef::env-github[]
 :suse: SUSE
 :current-year: 2019
 :product: {suse} Cloud Application Platform
-:version: 1.4
+:version: 1.4.1
 :rn-url: https://www.suse.com/releasenotes
 :doc-url: https://www.suse.com/documentation/cloud-application-platform-1
 :deployment-url: https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/part_cap_deployment.html

--- a/adoc/support-statement.adoc
+++ b/adoc/support-statement.adoc
@@ -3,7 +3,7 @@ ifdef::env-github[]
 :suse: SUSE
 :current-year: 2019
 :product: {suse} Cloud Application Platform
-:version: 1.4
+:version: 1.4.1
 :rn-url: https://www.suse.com/releasenotes
 :doc-url: https://www.suse.com/documentation/cloud-application-platform-1
 :deployment-url: https://www.suse.com/documentation/cloud-application-platform-1/book_cap_guides/data/part_cap_deployment.html


### PR DESCRIPTION
QA is getting close to giving thumbs up to scf 2.17.1 so it's time to populate the 1.4.1 changes. Entries file has not been updated with the new version number (yet).